### PR TITLE
remove `--disable-dev-shm-usage` from testem.js

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
         '--disable-gpu',
-        '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',
         '--remote-debugging-port=0',


### PR DESCRIPTION
looks like it is causing issues during build in circleci: https://discuss.circleci.com/t/fontconfig-error-on-node-10-browsers/29029/9